### PR TITLE
Adds a method to enable programmatic triggering of the dropdown from …

### DIFF
--- a/src/components/VueCountryCode.vue
+++ b/src/components/VueCountryCode.vue
@@ -106,6 +106,7 @@ export default {
     return {
       activeCountry: { iso2: "" },
       open: false,
+      manualTrigger: false,
       selectedIndex: null,
       typeToFindInput: "",
       typeToFindTimer: null
@@ -197,7 +198,20 @@ export default {
       }
       this.open = !this.open;
     },
+    // Method to enable programmatic trigger of the dropdown by an element in the DOM
+    manualDropdown() {
+      if (this.disabled) {
+        return;
+      }
+      this.manualTrigger = true;
+      this.open = true;
+    },
     clickedOutside() {
+      // If this was caused by a programmatic trigger, allow it, then reset the manualTrigger
+      if(this.manualTrigger) {
+        this.manualTrigger = false;
+        return;
+      }
       this.open = false;
     },
     keyboardNav(e) {


### PR DESCRIPTION
…the DOM.

Hi,

I ran into a case where I wanted this component to be beside a read only input box, and I also wanted this input box to trigger the dropdown but the "clickedOutside" method was preventing this from happening so I added the functionality and created a PR as there might be others like me wanting this.

Here's a GIF describing this: [image](https://gfycat.com/physicalunacceptablehartebeest)
